### PR TITLE
fix: use correct selector when updating player level

### DIFF
--- a/idle.js
+++ b/idle.js
@@ -60,7 +60,7 @@ class BotGUI {
 	}
 
 	updateLevel(level) {
-		document.getElementById('salienbot_zone').innerText = level;
+		document.getElementById('salienbot_level').innerText = level;
 	}
 
 	updateEstimatedTime(secondsLeft) {


### PR DESCRIPTION
The selector used when updating the player's level from a response incorrectly refers to the target zone.