### PR TITLE
Better AJAX errors handling

### DIFF
--- a/idle.js
+++ b/idle.js
@@ -133,13 +133,11 @@ function ajaxErrorHandling(ajaxObj, params, messagesArray) {
 	ajaxObj.tryCount++;
 	if (ajaxObj.tryCount <= ajaxObj.retryLimit) {
 		var currentTask = "Retrying to " + messagesArray[0] + " (Retry #" + ajaxObj.tryCount + "). Error: " + params.xhr.status + ": " + params.thrownError;
-		console.log(currentTask);
 		gui.updateTask(currentTask);
-		$.ajax(ajaxObj);
+		$J.ajax(ajaxObj);
 		return;
 	}
 	var currentTask = "Error " + messagesArray[1] + ": " + params.xhr.status + ": " + params.thrownError + " (Max retries reached).";
-	console.log(currentTask);
 	gui.updateTask(currentTask);
 	return;
 }

--- a/idle.js
+++ b/idle.js
@@ -129,16 +129,16 @@ function calculateTimeToNextLevel() {
 }
 
 // Handle AJAX errors to avoid the script to be locked by a single API error
-function ajaxErrorHandling(ajaxObj, messagesArray) {
+function ajaxErrorHandling(ajaxObj, params, messagesArray) {
 	ajaxObj.tryCount++;
 	if (ajaxObj.tryCount <= ajaxObj.retryLimit) {
-		var currentTask = "Retrying to " + messagesArray[0] + " (Retry #" + ajaxObj.tryCount + "). Error: " + xhr.status + ": " + thrownError;
+		var currentTask = "Retrying to " + messagesArray[0] + " (Retry #" + ajaxObj.tryCount + "). Error: " + params.xhr.status + ": " + params.thrownError;
 		console.log(currentTask);
 		gui.updateTask(currentTask);
 		$.ajax(ajaxObj);
 		return;
 	}
-	var currentTask = "Error " + messagesArray[1] + ": " + xhr.status + ": " + thrownError + " (Max retries reached).";
+	var currentTask = "Error " + messagesArray[1] + ": " + params.xhr.status + ": " + params.thrownError + " (Max retries reached).";
 	console.log(currentTask);
 	gui.updateTask(currentTask);
 	return;
@@ -231,7 +231,12 @@ var INJECT_start_round = function(zone, access_token, attempt_no) {
 		},
 		error: function (xhr, ajaxOptions, thrownError) {
 			var messagesArray = ["start the round", "starting round"];
-			ajaxErrorHandling(this, messagesArray);
+			var ajaxParams = {
+				xhr: xhr, 
+				ajaxOptions: ajaxOptions, 
+				thrownError: thrownError
+			};
+			ajaxErrorHandling(this, ajaxParams, messagesArray);
 		}
 	});
 }
@@ -326,7 +331,12 @@ var INJECT_end_round = function(attempt_no) {
 		},
 		error: function (xhr, ajaxOptions, thrownError) {
 			var messagesArray = ["end the round", "ending round"];
-			ajaxErrorHandling(this, messagesArray);
+			var ajaxParams = {
+				xhr: xhr, 
+				ajaxOptions: ajaxOptions, 
+				thrownError: thrownError
+			};
+			ajaxErrorHandling(this, ajaxParams, messagesArray);
 		}
 	});
 }
@@ -352,7 +362,12 @@ var INJECT_leave_round = function() {
 		success: function(data) {},
 		error: function (xhr, ajaxOptions, thrownError) {
 			var messagesArray = ["leave the round", "leaving round"];
-			ajaxErrorHandling(this, messagesArray);
+			var ajaxParams = {
+				xhr: xhr, 
+				ajaxOptions: ajaxOptions, 
+				thrownError: thrownError
+			};
+			ajaxErrorHandling(this, ajaxParams, messagesArray);
 		}
 	});
 
@@ -408,7 +423,12 @@ var INJECT_update_grid = function() {
 		},
 		error: function (xhr, ajaxOptions, thrownError) {
 			var messagesArray = ["update the grid", "updating the grid"];
-			ajaxErrorHandling(this, messagesArray);
+			var ajaxParams = {
+				xhr: xhr, 
+				ajaxOptions: ajaxOptions, 
+				thrownError: thrownError
+			};
+			ajaxErrorHandling(this, ajaxParams, messagesArray);
 		}
 	});
 }
@@ -486,7 +506,12 @@ function GetBestPlanet() {
 		},
 		error: function (xhr, ajaxOptions, thrownError) {
 			var messagesArray = ["get active planets", "getting active planets"];
-			ajaxErrorHandling(this, messagesArray);
+			var ajaxParams = {
+				xhr: xhr, 
+				ajaxOptions: ajaxOptions, 
+				thrownError: thrownError
+			};
+			ajaxErrorHandling(this, ajaxParams, messagesArray);
 		}
 	});
 	

--- a/idle.js
+++ b/idle.js
@@ -132,9 +132,9 @@ function calculateTimeToNextLevel() {
 function ajaxErrorHandling(ajaxObj, params, messagesArray) {
 	ajaxObj.tryCount++;
 	if (ajaxObj.tryCount <= ajaxObj.retryLimit) {
-		var currentTask = "Retrying to " + messagesArray[0] + " (Retry #" + ajaxObj.tryCount + "). Error: " + params.xhr.status + ": " + params.thrownError;
+		var currentTask = "Retrying in 5s to " + messagesArray[0] + " (Retry #" + ajaxObj.tryCount + "). Error: " + params.xhr.status + ": " + params.thrownError;
 		gui.updateTask(currentTask);
-		$J.ajax(ajaxObj);
+		setTimeout(function() { $J.ajax(ajaxObj); }, 5000);
 		return;
 	}
 	var currentTask = "Error " + messagesArray[1] + ": " + params.xhr.status + ": " + params.thrownError + " (Max retries reached).";


### PR DESCRIPTION
It should avoid the script to automatically stop after only one error on some important requests.  
I used the max_retries we're also using when the request return an empty response. So it'll not flood the Steam servers and will stop if it can't succeed after that.