### PR TITLE
Avoiding parallel error handling w/ update_grid()

### DIFF
--- a/idle.js
+++ b/idle.js
@@ -526,6 +526,7 @@ function GetBestPlanet() {
 		return current_planet_id;
 	var bestPlanetId = undefined;
 	var activePlanetsScore = [];
+	var planetsMaxDifficulty = [];
 	var maxScore = 0;
 	var numberErrors = 0;
 	
@@ -542,6 +543,7 @@ function GetBestPlanet() {
 			data.response.planets.forEach( function(planet) {
 				if (planet.state.active == true && planet.state.captured == false)
 					activePlanetsScore[planet.id] = 0;
+					planetsMaxDifficulty[planet.id] = 0;
 			});
 		},
 		error: function (xhr, ajaxOptions, thrownError) {
@@ -567,6 +569,8 @@ function GetBestPlanet() {
 				data.response.planets[0].zones.forEach( function ( zone ) {
 					if (zone.difficulty >= 1 && zone.difficulty <= 7 && zone.captured == false)
 						activePlanetsScore[planet_id] += Math.ceil(Math.pow(10, (zone.difficulty - 1) * 2) * (1 - zone.capture_progress));
+						if (zone.difficulty > planetsMaxDifficulty[planet_id])
+							planetsMaxDifficulty[planet_id] = zone.difficulty;
 				});
 			},
 			error: function() {
@@ -579,6 +583,12 @@ function GetBestPlanet() {
 		}
 	});
 	console.log(activePlanetsScore);
+	
+	// Check if the maximum difficulty available on the best planet is the same as the current one
+	// If yes, no need to move
+	if (planetsMaxDifficulty[bestPlanetId] == auto_switch_planet.current_difficulty)
+		return current_planet_id;
+	
 	// Prevent a planet switch if there were >= 2 errors while fetching planets or if there's an error while fetching the current planet score
 	if (numberErrors >= 2 || ((current_planet_id in activePlanetsScore) && activePlanetsScore[current_planet_id] == 0))
 		return null;

--- a/idle.js
+++ b/idle.js
@@ -586,7 +586,7 @@ function GetBestPlanet() {
 	
 	// Check if the maximum difficulty available on the best planet is the same as the current one
 	// If yes, no need to move
-	if (planetsMaxDifficulty[bestPlanetId] == auto_switch_planet.current_difficulty)
+	if ((current_planet_id in activePlanetsScore) && planetsMaxDifficulty[bestPlanetId] == auto_switch_planet.current_difficulty)
 		return current_planet_id;
 	
 	// Prevent a planet switch if there were >= 2 errors while fetching planets or if there's an error while fetching the current planet score

--- a/idle.js
+++ b/idle.js
@@ -217,7 +217,7 @@ var INJECT_start_round = function(zone, access_token, attempt_no) {
 		success: function(data) {
 			if( $J.isEmptyObject(data.response) ) {
 				// Check if the zone is completed
-				INJECT_update_grid();
+				INJECT_update_grid(false); // Error handling set to false to avoid too much parallel calls with the setTimeout below
 				if(window.gGame.m_State.m_Grid.m_Tiles[target_zone].Info.captured || attempt_no >= max_retry) {
 					if (auto_switch_planet.active == true)
 						CheckSwitchBetterPlanet();
@@ -327,7 +327,7 @@ var INJECT_end_round = function(attempt_no) {
 		success: function(data) {
 			if( $J.isEmptyObject(data.response) ) {
 				// Check if the zone is completed
-				INJECT_update_grid();
+				INJECT_update_grid(false); // Error handling set to false to avoid too much parallel calls with the setTimeout below
 				if(window.gGame.m_State.m_Grid.m_Tiles[target_zone].Info.captured || attempt_no >= max_retry) {
 					if (auto_switch_planet.active == true)
 						CheckSwitchBetterPlanet();
@@ -431,9 +431,11 @@ var INJECT_update_player_info = function() {
 }
 
 // Update the zones of the grid (map) on the current planet
-var INJECT_update_grid = function() {
+var INJECT_update_grid = function(error_handling) {
 	if(current_planet_id === undefined)
 		return;
+	if (error_handling === undefined)
+		error_handling = true;
 
 	gui.updateTask('Updating grid', true);
 
@@ -455,13 +457,15 @@ var INJECT_update_grid = function() {
 			console.log("Successfully updated map data on planet: " + current_planet_id);
 		},
 		error: function (xhr, ajaxOptions, thrownError) {
-			var messagesArray = ["update the grid", "updating the grid"];
-			var ajaxParams = {
-				xhr: xhr, 
-				ajaxOptions: ajaxOptions, 
-				thrownError: thrownError
-			};
-			ajaxErrorHandling(this, ajaxParams, messagesArray);
+			if (error_handling == true) {
+				var messagesArray = ["update the grid", "updating the grid"];
+				var ajaxParams = {
+					xhr: xhr, 
+					ajaxOptions: ajaxOptions, 
+					thrownError: thrownError
+				};
+				ajaxErrorHandling(this, ajaxParams, messagesArray);
+			}
 		}
 	});
 }


### PR DESCRIPTION
Should fix #55.  
It could totally stop the script at the end because it'll trigger both the AJAX error handling if update_grid() fails and the empty response handling in start_round() and end_round(). So AJAX error handling is disabled specifically in the update_grid() calls in start_round() and end_round(). One error handling is already enough :p.  

Edit : Added a little improvement too, to avoid useless planet switches in case our current difficulty is the same as the highest difficulty available on the technically "best planet".  
_I also think we're (near ?) ready to set the auto planet switch to true. But some users may want to stay on their planet, so... Not sure about changing the default setting._