### PR TITLE
Adding a way to unstuck the game script if needed

### DIFF
--- a/idle.js
+++ b/idle.js
@@ -896,9 +896,13 @@ var INJECT_init = function() {
 };
 
 var INJECT_disable_animations = function() {
-	var confirmed = confirm("Disabling animations will vastly reduce resources used, but you will no longer be able to manually swap zones until you refresh. Continue?");
+	var confirmed = confirm("Disabling animations will vastly reduce resources used, but you will no longer be able to manually swap zones until you refresh. Additionally, auto-planet-switching will be disabled. Continue?");
 
 	if(confirmed) {
+		// Disable planet-switching
+		auto_switch_planet.active=false;
+
+		// Disable animations
 		requestAnimationFrame = function(){};
 		$J("#disableAnimsBtn").prop("disabled",true).prop("value", "Animations Disabled.");
 	}

--- a/idle.js
+++ b/idle.js
@@ -326,11 +326,12 @@ var INJECT_wait_for_end = function() {
 	// Update GUI
 	gui.updateTask("Waiting " + Math.max(time_remaining, 0) + "s for round to end", false);
 	gui.updateStatus(true);
-	gui.updateEstimatedTime(calculateTimeToNextLevel())
-	gui.progressbar.SetValue(time_passed_ms/(resend_frequency*1000))
+	if (target_zone != -1)
+		gui.updateEstimatedTime(calculateTimeToNextLevel());
+	gui.progressbar.SetValue(time_passed_ms/(resend_frequency*1000));
 
 	// Wait
-	var wait_time = update_length*1000;;
+	var wait_time = update_length*1000;
 	var callback;
 	
 	// use absolute timestamps to calculate if the game is over, since setTimeout timings are not always reliable

--- a/idle.js
+++ b/idle.js
@@ -927,6 +927,7 @@ var INJECT_disable_animations = function() {
 	if(confirmed) {
 		// Disable planet-switching
 		auto_switch_planet.active=false;
+		$J('#planetSwitchCheckbox').prop('checked', false).attr("disabled", true);
 
 		// Disable animations
 		requestAnimationFrame = function(){};

--- a/idle.js
+++ b/idle.js
@@ -238,7 +238,7 @@ var INJECT_start_round = function(zone, access_token, attempt_no) {
 			if( $J.isEmptyObject(data.response) ) {
 				// Check if the zone is completed
 				INJECT_update_grid(false); // Error handling set to false to avoid too much parallel calls with the setTimeout below
-				if(window.gGame.m_State.m_Grid.m_Tiles[target_zone].Info.captured || attempt_no >= max_retry) {
+				if(window.gGame.m_State.m_Grid.m_Tiles[zone].Info.captured || attempt_no >= max_retry) {
 					if (auto_switch_planet.active == true)
 						CheckSwitchBetterPlanet();
 					else

--- a/idle.js
+++ b/idle.js
@@ -61,7 +61,8 @@ class BotGUI {
 				`<p style="display: none;" id="salienbot_zone_difficulty_div"><b>Zone Difficulty:</b> <span id="salienbot_zone_difficulty"></span></p>`,
 				'<p><b>Level:</b> <span id="salienbot_level">' + this.state.level + '</span> &nbsp;&nbsp;&nbsp;&nbsp; <b>EXP:</b> <span id="salienbot_exp">' + this.state.exp + '</span></p>',
 				'<p><b>Lvl Up In:</b> <span id="salienbot_esttimlvl"></span></p>',
-				'<p><input id="disableAnimsBtn" type="button" onclick="INJECT_disable_animations()" value="Disable Animations"/></p>',
+				'<p><input id="planetSwitchCheckbox" type="checkbox"/> Automatic Planet Switching</p>',
+				'<p><input id="disableAnimsBtn" type="button" value="Disable Animations"/></p>',
 			'</div>'
 		].join(''))
 
@@ -149,6 +150,15 @@ function initGUI(){
 			level: gPlayerInfo.level,
 			exp: gPlayerInfo.score
 		});
+
+		// Set our onclicks
+		$J('#disableAnimsBtn').click(function() {
+			INJECT_disable_animations();
+		});
+		$J('#planetSwitchCheckbox').change(function() {
+			auto_switch_planet.active = this.checked;
+		});
+		$J('#planetSwitchCheckbox').prop('checked', auto_switch_planet.active);
 
 		// Run the global initializer, which will call the function for whichever screen you're in
 		INJECT_init();

--- a/idle.js
+++ b/idle.js
@@ -597,10 +597,11 @@ function GetBestPlanet() {
 			data: { id: planet_id },
 			success: function(data) {
 				data.response.planets[0].zones.forEach( function ( zone ) {
-					if (zone.difficulty >= 1 && zone.difficulty <= 7 && zone.captured == false)
+					if (zone.difficulty >= 1 && zone.difficulty <= 7 && zone.captured == false) {
 						activePlanetsScore[planet_id] += Math.ceil(Math.pow(10, (zone.difficulty - 1) * 2) * (1 - zone.capture_progress));
 						if (zone.difficulty > planetsMaxDifficulty[planet_id])
 							planetsMaxDifficulty[planet_id] = zone.difficulty;
+					}
 				});
 			},
 			error: function() {

--- a/idle.js
+++ b/idle.js
@@ -752,7 +752,6 @@ var INJECT_leave_planet = function(callback) {
 
 	// Cancel timeouts
 	clearTimeout(current_timeout);
-	clearInterval(check_game_state);
 
 	// Leave our current round if we haven't.
 	INJECT_leave_round();
@@ -815,6 +814,8 @@ var INJECT_init_battle_selection = function() {
 	gui.updateTask("Initializing Battle Selection Menu.");
 
 	// Check the game state for hangups occasionally
+	if (check_game_state !== undefined)
+		clearInterval(check_game_state);
 	check_game_state = setInterval(checkUnlockGameState, 60000);
 	
 	// Auto join best zone at first

--- a/idle.js
+++ b/idle.js
@@ -686,11 +686,22 @@ function CheckSwitchBetterPlanet(difficulty_call) {
 }
 
 var INJECT_switch_planet = function(planet_id, callback) {
-	// ONLY usable from battle selection
+	// ONLY usable from battle selection, if at planet selection, run join instead
+	if(gGame.m_State instanceof CPlanetSelectionState)
+		join_planet_helper(planet_id);
 	if(!(gGame.m_State instanceof CBattleSelectionState))
 		return;
 
 	gui.updateTask("Attempting to move to Planet #" + planet_id);
+
+	// Leave our current round if we haven't.
+	INJECT_leave_round();
+
+	// Leave the planet
+	INJECT_leave_planet(function() {
+		// Join Planet
+		join_planet_helper(planet_id);
+	});
 
 	function wait_for_state_load() {
 		if(gGame.m_IsStateLoading || gGame.m_State instanceof CPlanetSelectionState) {
@@ -701,12 +712,7 @@ var INJECT_switch_planet = function(planet_id, callback) {
 			callback();
 	}
 
-	// Leave our current round if we haven't.
-	INJECT_leave_round();
-
-	// Leave the planet
-	INJECT_leave_planet(function() {
-
+	function join_planet_helper(planet_id) {
 		// Make sure the planet_id is valid (or we'll error out)
 		var valid_planets = gGame.m_State.m_rgPlanets;
 		var found = false;
@@ -719,7 +725,6 @@ var INJECT_switch_planet = function(planet_id, callback) {
 			return;
 		}
 
-		// Join Planet
 		INJECT_join_planet(planet_id,
 			function ( response ) {
 				gGame.ChangeState( new CBattleSelectionState( planet_id ) );
@@ -728,8 +733,7 @@ var INJECT_switch_planet = function(planet_id, callback) {
 			function ( response ) {
 				ShowAlertDialog( 'Join Planet Error', 'Failed to join planet. Please reload your game or try again shortly.' );
 			});
-	});
-
+	}
 }
 
 // Leave the planet


### PR DESCRIPTION
- Check made every minute to see if the game script is running. If no round started in the last 15 minutes, we try to start a new round.  
- We "deny" any call to update_grid() if a successful one happened in the last 13 seconds.  
- Temporal quick fix for the issue #59.  
- Improvement in the planet switch : if the best planet found has an higher difficulty while there's errors, since we've the data on our current difficulty, we switch.  
- Auto planet switching turned on by default. You can still disable it if you want. But it seems CORS issues are a thing from the past maybe ? This would close issue #22.  
_Edit : So i'll say this fix #59, fix #50 and fix #62._