### PR TITLE
Little fix in score calc of GetBestPlanet()

### DIFF
--- a/idle.js
+++ b/idle.js
@@ -618,7 +618,9 @@ function GetBestPlanet() {
 			success: function(data) {
 				data.response.planets[0].zones.forEach( function ( zone ) {
 					if (zone.difficulty >= 1 && zone.difficulty <= 7 && zone.captured == false) {
-						activePlanetsScore[planet_id] += Math.ceil(Math.pow(10, (zone.difficulty - 1) * 2) * (1 - zone.capture_progress));
+						var zoneProgress = (zone.capture_progress === undefined) ? 0 : zone.capture_progress;
+						var zoneScore = Math.ceil(Math.pow(10, (zone.difficulty - 1) * 2) * (1 - zoneProgress));
+						activePlanetsScore[planet_id] += isNaN(zoneScore) ? 0 : zoneScore;
 						if (zone.difficulty > planetsMaxDifficulty[planet_id])
 							planetsMaxDifficulty[planet_id] = zone.difficulty;
 					}


### PR DESCRIPTION
For an unknown reason, when a new planet is there, one (or several ?) zone can have their capture_progress propriety undefined. Added a check on this matter to avoid any planet score equalling NaN.