### PR TITLE
Update Lvl Up In during boss fights

### DIFF
--- a/idle.js
+++ b/idle.js
@@ -411,8 +411,8 @@ var INJECT_report_boss_damage = function() {
 		boss_options.last_report = undefined;
 		boss_options.current_max_hp = undefined;
 		current_game_is_boss = false;
+		bossXP = 0;
 		INJECT_leave_round();
-		bossXP = 0
 		
 		if (auto_switch_planet.active == true)
 			CheckSwitchBetterPlanet();

--- a/idle.js
+++ b/idle.js
@@ -43,6 +43,7 @@ var boss_options = {
 	"last_report": undefined, // Used in the check of the game script state and unlock it if needed 
 	"current_max_hp": undefined // Used in damages calculation
 }
+var bossXP = 0
 var current_game_is_boss = false; // State if we're entering / in a boss battle or not
 
 class BotGUI {
@@ -212,7 +213,7 @@ function calculateTimeToNextLevel() {
 		return -1;
 	
 	const nextScoreAmount = get_max_score(target_zone);	
-	const missingExp = Math.ceil((gPlayerInfo.next_level_score - gPlayerInfo.score) / nextScoreAmount) * nextScoreAmount;
+	const missingExp = Math.ceil((gPlayerInfo.next_level_score - gPlayerInfo.score - bossXP) / nextScoreAmount) * nextScoreAmount;
 	const roundTime = resend_frequency + update_length;
 
 	const secondsLeft = missingExp / nextScoreAmount * roundTime - time_passed_ms / 1000;
@@ -374,6 +375,7 @@ var INJECT_report_boss_damage = function() {
 			gui.updateTask("Waiting for players...");
 		} else {
 			results.response.boss_status.boss_players.forEach( function(player) {
+				bossXP = player.xp_earned
 				if (player.accountid == account_id) {
 					if (player.time_last_heal !== undefined)
 						boss_options.last_heal = player.time_last_heal;
@@ -409,6 +411,7 @@ var INJECT_report_boss_damage = function() {
 		boss_options.current_max_hp = undefined;
 		current_game_is_boss = false;
 		INJECT_leave_round();
+		bossXP = 0
 		
 		if (auto_switch_planet.active == true)
 			CheckSwitchBetterPlanet();

--- a/idle.js
+++ b/idle.js
@@ -376,7 +376,6 @@ var INJECT_report_boss_damage = function() {
 		} else {
 			results.response.boss_status.boss_players.forEach( function(player) {
 				bossXP = player.xp_earned;
-				gui.updateEstimatedTime(calculateTimeToNextLevel());
 				if (player.accountid == account_id) {
 					if (player.time_last_heal !== undefined)
 						boss_options.last_heal = player.time_last_heal;
@@ -392,6 +391,7 @@ var INJECT_report_boss_damage = function() {
 					}
 				}
 			});
+			gui.updateEstimatedTime(calculateTimeToNextLevel());
 			gui.progressbar.SetValue((results.response.boss_status.boss_max_hp - results.response.boss_status.boss_hp) / results.response.boss_status.boss_max_hp);
 			if (boss_options.current_max_hp === undefined)
 				boss_options.current_max_hp = results.response.boss_status.boss_max_hp;

--- a/idle.js
+++ b/idle.js
@@ -375,7 +375,8 @@ var INJECT_report_boss_damage = function() {
 			gui.updateTask("Waiting for players...");
 		} else {
 			results.response.boss_status.boss_players.forEach( function(player) {
-				bossXP = player.xp_earned
+				bossXP = player.xp_earned;
+				gui.updateEstimatedTime(calculateTimeToNextLevel());
 				if (player.accountid == account_id) {
 					if (player.time_last_heal !== undefined)
 						boss_options.last_heal = player.time_last_heal;


### PR DESCRIPTION
This should make the GUI update the lvl up in field during boss battles.  It doesn't attempt to estimate how much experience you'll get from the battle, so it ends up taking off ~7m 24s every time it updates (instead of estimating how much EXP you'll get and factoring that in).  It also doesn't update the EXP field in the GUI (which would be nice, however I don't want to get into that right now) - as a result, it also temporarily resets between the end of the boss battle and the EXP updating (usually at the end of the next battle).

I've tested this both in and out of boss battles and it seems to work fine, but I'm not especially familiar with Javascript, so let me know if there are any problems.